### PR TITLE
Refactor load.py to have an agnostic config

### DIFF
--- a/lib/api_ckan_load.py
+++ b/lib/api_ckan_load.py
@@ -34,7 +34,7 @@ dag = DAG(
 
 data_resource = {
     'path': './r2.csv',
-    'ckan_resource_id': 'dd61b12d-49c7-4529-a633-7c8388dc773e',
+    'ckan_resource_id': '00dff48a-6537-4652-a430-20397a6f2ea0',
     'schema': {
         'fields': [
             {'name': 'FID', 'type': 'text'}
@@ -42,10 +42,17 @@ data_resource = {
     },
 }
 
+def get_config():
+    config = {}
+    config['CKAN_SYSADMIN_API_KEY'] = Variable.get('CKAN_SYSADMIN_API_KEY')
+    config['CKAN_SITE_URL'] = Variable.get('CKAN_SITE_URL')
+    return config
+
+
 
 def task_delete_datastore_table():
     logging.info('Invoking Delete Datastore')
-    return load.delete_datastore_table(data_resource)
+    return load.delete_datastore_table(data_resource, get_config())
 
 
 delete_datastore_table_task = PythonOperator(
@@ -58,7 +65,7 @@ delete_datastore_table_task = PythonOperator(
 
 def task_create_datastore_table():
     logging.info('Invoking Create Datastore')
-    return load.create_datastore_table(data_resource)
+    return load.create_datastore_table(data_resource, get_config())
 
 
 create_datastore_table_task = PythonOperator(
@@ -80,7 +87,7 @@ def get_connection():
 def task_load_csv_to_postgres_via_copy():
     logging.info('Loading CSV to postgres')
     return load.load_csv_to_postgres_via_copy(
-        data_resource, {}, get_connection()
+        data_resource, get_config(), get_connection()
     )
 
 
@@ -94,7 +101,7 @@ load_csv_to_postgres_via_copy_task = PythonOperator(
 def task_restore_indexes_and_set_datastore_active():
     logging.info('Restore Indexes')
     return load.restore_indexes_and_set_datastore_active(
-        data_resource, {}, get_connection()
+        data_resource, get_config(), get_connection()
     )
 
 

--- a/lib/load.py
+++ b/lib/load.py
@@ -9,12 +9,6 @@ import requests
 
 from sqlalchemy import create_engine
 
-from airflow.models import Variable
-
-# def get_connection():
-#     engine = create_engine(Variable.get('CKAN_DATASTORE_WRITE_URL'))
-#     return engine.raw_connection()
-
 
 def load_csv(data_resource, config={}, connection=None):
     '''Loads a CSV into DataStore. Does not create the indexes.'''
@@ -31,10 +25,10 @@ def load_csv(data_resource, config={}, connection=None):
 
 
 def delete_datastore_table(data_resource, config={}):
-    header = {'Authorization': Variable.get('CKAN_SYSADMIN_API_KEY')}
+    header = {'Authorization': config['CKAN_SYSADMIN_API_KEY']}
     try:
         response = requests.post(
-            urljoin(Variable.get('CKAN_SITE_URL'), '/api/3/action/datastore_delete'),
+            urljoin(config['CKAN_SITE_URL'], '/api/3/action/datastore_delete'),
             headers=header,
             json={
                 "resource_id": data_resource['ckan_resource_id'],
@@ -64,8 +58,8 @@ def create_datastore_table(data_resource, config={}):
     data_dict['force'] = True
     try:
         response = requests.post(
-            urljoin(Variable.get('CKAN_SITE_URL'), '/api/3/action/datastore_create'),
-            headers={'Authorization': Variable.get('CKAN_SYSADMIN_API_KEY')},
+            urljoin(config['CKAN_SITE_URL'], '/api/3/action/datastore_create'),
+            headers={'Authorization': config['CKAN_SYSADMIN_API_KEY']},
             json=data_dict
         )
         if response.status_code == 200:


### PR DESCRIPTION
Relates to the first task on #10 ; use a continuation on the methods is not ideal yet. We could refactor and create a class wrapping the original library. Can we make it a singleton? In my opinion, it would make sense.

@rufuspollock This refactor suggestion is a matter of cleaning the codebase. Is there time to do so? Work est (to refactor classes and the tests that will break: 2h)