### PR TITLE
[Refactor][l] Splitting main lib files

### DIFF
--- a/dags/api_ckan_load_single_node.py
+++ b/dags/api_ckan_load_single_node.py
@@ -1,0 +1,73 @@
+# Standard library imports
+import logging
+import time
+import json
+import ast
+from datetime import datetime
+
+# Local imports
+from lib.hybrid_load import delete_datastore_table, create_datastore_table
+from lib.api_load import load_resource_via_api
+
+from lib.file_conversion.csv_to_json import convert
+
+# Third-party library imports
+from airflow import DAG
+from airflow.exceptions import AirflowException
+
+from airflow.models import Variable
+from airflow.operators.python_operator import PythonOperator
+from airflow.utils.dates import days_ago
+
+
+
+single_dag_args = {
+    'owner': 'airflow',
+    'start_date': datetime.now(),
+    'params': { 
+        "resource_id": "res-id-123",
+        "schema_fields_array": "['field1', 'field2']", 
+        "csv_input": "path/to/my.csv", 
+        "json_output": "path/to/my.json"
+    }
+}
+
+single_dag = DAG(
+    dag_id='ckan_api_load_single_step',
+    default_args=single_dag_args,
+    schedule_interval=None,
+    tags=['api_load']
+)
+
+def get_config():
+    config = {}
+    config['CKAN_SYSADMIN_API_KEY'] = Variable.get('CKAN_SYSADMIN_API_KEY')
+    config['CKAN_SITE_URL'] = Variable.get('CKAN_SITE_URL')
+    return config
+
+
+def full_load(resource_id, schema_fields, csv_input, json_output, **kwargs):
+    logging.info('Deleting Datastore if exists')
+    delete_datastore_table(resource_id, get_config())
+    logging.info('Invoking Create Datastore')
+    data_resource_fields = ast.literal_eval(schema_fields)
+    create_datastore_table(resource_id, data_resource_fields, get_config())
+    logging.info('Converting resources to json')
+    convert(csv_input, json_output)
+    logging.info('Loading CSV via API')
+    try:
+        with open(json_output) as f:
+            records = json.load(f)
+            return load_resource_via_api(
+                resource_id, records, get_config())
+    except Exception as e:
+        return {"success": False, "errors": [e]}
+
+
+full_load_task = PythonOperator(
+    task_id='full_load_via_api',
+    provide_context=True,
+    python_callable=full_load,
+    op_kwargs={'resource_id': "{{ params.resource_id }}", 'schema_fields': "{{ params.schema_fields_array }}", 'csv_input': "{{ params.csv_input }}", 'json_output': "{{ params.json_output }}" },
+    dag=single_dag
+)

--- a/dags/hybrid_ckan_load.py
+++ b/dags/hybrid_ckan_load.py
@@ -6,7 +6,7 @@ import pandas as pd
 import time
 
 # Local imports
-from lib.load import *
+from lib.hybrid_load import *
 
 # Third-party library imports
 from airflow import DAG

--- a/lib/api_load.py
+++ b/lib/api_load.py
@@ -1,0 +1,43 @@
+# Standard library imports
+from urllib.parse import urljoin
+import hashlib
+import logging as log
+
+# Third-party library imports
+import json
+import requests
+
+
+class DatastoreEncoder(json.JSONEncoder):
+    def default(self, obj):
+        if isinstance(obj, datetime.datetime):
+            return obj.isoformat()
+        if isinstance(obj, decimal.Decimal):
+            return str(obj)
+
+        return json.JSONEncoder.default(self, obj)
+
+
+def load_resource_via_api(ckan_resource_id, records, config={}):
+    log.info("Loading resource via API")
+    try:
+        request = {
+           'resource_id': ckan_resource_id,
+           'force': True,
+           'records': records}
+
+        url = urljoin(config['CKAN_SITE_URL'], '/api/3/action/datastore_create')
+        response = requests.post(url,
+                      data=json.dumps(request, cls=DatastoreEncoder),
+                      headers={'Content-Type': 'application/json',
+                               'Authorization': config['CKAN_SYSADMIN_API_KEY']}
+                      )
+        if response.status_code == 200:
+            resource_json = response.json()
+            return {'success': True, 'response_resource': resource_json}
+            log.info('Table was created successfuly')
+        else:
+            return response.json()
+
+    except Exception as e:
+        return {"success": False, "errors": [e]}


### PR DESCRIPTION
Tackling the Housekeeping task from #10:

- [x] Splitting previous `load.py` into two separate files: `hybrid_load` and `api_load`
- [x] Splitting DAG files. **This PR focuses on `dags/api_ckan_load_single_node.py`**, which contains a single node DAG that runs on airflow.
- [x] Cleans up unused code / imports/ comments
- [x] Gets rid of hard-coded json and any other pieces of that. Everything now is parameterized on DAG config.
- [x] Refactors `hybrid_load` to support a resource_id
- [x] Better method names (e.g. `load_resource_via_api` instead of `load_csv_via_api`
- [x] Docs