### PR TITLE
[bq_import][s]: change bq_table_name param + schema autodetect

### DIFF
--- a/aircan/dags/api_ckan_import_to_bq.py
+++ b/aircan/dags/api_ckan_import_to_bq.py
@@ -53,9 +53,9 @@ def task_import_resource_to_bq(**context):
     gc_file_url = context['params'].get('big_query', {}).get('gcs_uri')
     bq_project_id = context['params'].get('big_query', {}).get('bq_project_id')
     bq_dataset_id = context['params'].get('big_query', {}).get('bq_dataset_id')
-
-    bq_table_name = context['params'].get('resource', {}).get('ckan_resource_id').replace('-', '')
+    bq_table_name = context['params'].get('big_query', {}).get('bq_table_name')
     logging.info("bq_table_name: {}".format(bq_table_name))
+    
     raw_schema = context['params'].get('resource', {}).get('schema')
     eval_schema = json.loads(raw_schema)
     eval_schema = ast.literal_eval(eval_schema)

--- a/aircan/dependencies/google_cloud/bigquery_handler.py
+++ b/aircan/dependencies/google_cloud/bigquery_handler.py
@@ -10,13 +10,14 @@ def bq_import_csv(table_id, gcs_path, table_schema):
         job_config = bigquery.LoadJobConfig()
 
         schema = bq_schema_from_table_schema(table_schema)
-        job_config.schema = schema
+        #job_config.schema = schema
 
         job_config.skip_leading_rows = 1
         job_config.source_format = bigquery.SourceFormat.CSV
         # overwrite a Table
         job_config.write_disposition=bigquery.WriteDisposition.WRITE_TRUNCATE
-
+        # set schema autodetect
+        job_config.autodetect=True
         load_job = client.load_table_from_uri(
             gcs_path, table_id, job_config=job_config
         )


### PR DESCRIPTION
In this PR:

- `bq_table_name` param is changed and expecting to get the value directly from `aircan-connector`

- set schema autodetect for bigquery import process