### PR TITLE
Generate CSV from dump url and load to GCP.

### DIFF
--- a/aircan/dags/ckan_datastore_loader.py
+++ b/aircan/dags/ckan_datastore_loader.py
@@ -13,6 +13,7 @@ from datetime import date, timedelta
 from airflow import DAG
 from airflow.operators.python import PythonOperator, BranchPythonOperator
 from airflow.models import Variable
+from airflow.exceptions import AirflowSkipException
 
 from aircan.dependencies.postgres_loader import (
     load_csv_to_postgres_via_copy,
@@ -29,7 +30,8 @@ from aircan.dependencies.api_loader import (
     compare_schema,
     create_datastore_table,
     delete_datastore_table,
-    load_resource_via_api
+    load_resource_via_api,
+    generate_file_and_load_to_GCP
     )
 
 args = {
@@ -193,6 +195,9 @@ def task_push_data_into_datastore(**context):
     datastore_postgres_url = context['params'].get('ckan_config', {}).get('ckan_datastore_postgres_url')
     load_with_postgres_copy = context['params'].get('ckan_config', {}).get('aircan_load_with_postgres_copy') 
     chunk_size = context['params'].get('ckan_config', {}).get('aircan_datastore_chunk_insert_rows_size') 
+    global_append_datastore = context['params'].get('ckan_config', {}).get('aircan_append_or_update_datastore')
+    resource_dict['datastore_append_enabled'] = context['params'].get('resource', {}) \
+                    .get('datastore_append_or_update', global_append_datastore )
 
     if to_bool(load_with_postgres_copy):
         ti = context['ti']
@@ -232,9 +237,38 @@ push_data_into_datastore_task = PythonOperator(
 )
 # [END push_data_into_datastore_task]
 
+# [START generate_file_and_load_to_GCP]
+def task_generate_file_and_load_to_GCP(**context):
+    resource_dict = context['params'].get('resource', {})
+    ckan_config = context['params'].get('ckan_config', {})
+    global_append_datastore = context['params'].get('ckan_config', {}).get('aircan_append_or_update_datastore')
+    resource_dict['datastore_append_enabled'] = context['params'].get('resource', {}) \
+                    .get('datastore_append_or_update', global_append_datastore )
+    if not resource_dict['datastore_append_enabled']:
+        raise AirflowSkipException('Skipping GCP load as resource not configured to append to datastore')
+    generate_file_and_load_to_GCP(resource_dict, ckan_config)
+    return  {'success': True}
+
+    
+generate_file_and_push_to_GCP = PythonOperator(
+    task_id='generate_file_and_load_to_GCP',
+    provide_context=True,
+    python_callable=task_generate_file_and_load_to_GCP,
+    trigger_rule='none_failed_or_skipped',
+    dag=dag,
+    doc_md=dedent(
+        """\
+        ####  Generate file and push to GCP
+        This task generates file and push to GCP bucket for append enabled resources so that
+        it less impact when downloading resource file
+        """
+    ),
+)
+# [END generate_file_and_load_to_GCP]
 
 # [SET WORKFLOW ]
 check_schema_task.set_upstream(fetch_and_read_data_task)
 create_datastore_table_task.set_upstream(check_schema_task)
 push_data_into_datastore_task.set_upstream([create_datastore_table_task, check_schema_task])
+generate_file_and_push_to_GCP.set_upstream(push_data_into_datastore_task)
 # [END WORKFLOW]

--- a/aircan/dependencies/postgres_loader.py
+++ b/aircan/dependencies/postgres_loader.py
@@ -160,12 +160,15 @@ def load_csv_to_postgres_via_copy(connection=None, **kwargs):
                             update_set = ','.join(['"{0}"=EXCLUDED."{0}"'.format(field['name']) for field in fields])
                         ),
                         buffer_data)
-                    status_dict = {
-                        'res_id': resource_dict['ckan_resource_id'],
-                        'state': 'complete',
-                        'message': 'Data ingestion completed successfully for "{res_id}".'.format(
-                                    res_id = resource_dict['ckan_resource_id'])}
-                    aircan_status_update(site_url, api_key, status_dict)
+                        
+                    if not resource_dict['datastore_append_enabled']:
+                        # Do not mark yet as complete if append is enabled
+                        status_dict = {
+                            'res_id': resource_dict['ckan_resource_id'],
+                            'state': 'complete',
+                            'message': 'Data ingestion completed successfully for "{res_id}".'.format(
+                                        res_id = resource_dict['ckan_resource_id'])}
+                        aircan_status_update(site_url, api_key, status_dict)
                                     
                 except psycopg2.DataError as err:
                     # E is a str but with foreign chars e.g.

--- a/aircan/dependencies/s3_uploader.py
+++ b/aircan/dependencies/s3_uploader.py
@@ -1,0 +1,44 @@
+import json
+import logging
+import boto3
+
+class s3Uploader(object):
+    def __init__(self,**arg):
+        self.s3 = boto3.client(
+            service_name=arg['service_name'],
+            aws_access_key_id=arg['aws_access_key_id'],
+            aws_secret_access_key=arg['aws_secret_access_key'],
+            endpoint_url=arg['endpoint_url'],
+            region_name=arg['region_name'],
+        )
+        self.bucket_name = arg['bucket_name']
+    
+    def upload_file(self, file_path, file_name):
+        self.s3.upload_file(file_path, self.bucket_name, file_name)
+
+    def upload_fileobj(self, fileobj, file_name):
+        self.s3.upload_fileobj(fileobj, self.bucket_name, file_name)
+
+    def upload_string(self, string, file_name):
+        self.s3.put_object(Body=string, Bucket=self.bucket_name, Key=file_name)
+
+    def upload_json(self, json_obj, file_name):
+        self.s3.put_object(Body=json.dumps(json_obj), Bucket=self.bucket_name, Key=file_name)
+
+    def upload_bytes(self, bytes, file_name):
+        self.s3.put_object(Body=bytes, Bucket=self.bucket_name, Key=file_name)
+
+    def upload_file_to_s3(self, file_path, file_name, content_type):
+        self.s3.upload_file(file_path, self.bucket_name, file_name, ExtraArgs={'ContentType': content_type})
+
+    def upload_fileobj_to_s3(self, fileobj, file_name, content_type):
+        self.s3.upload_fileobj(fileobj, self.bucket_name, file_name, ExtraArgs={'ContentType': content_type})
+
+    def upload_string_to_s3(self, string, file_name, content_type):
+        self.s3.put_object(Body=string, Bucket=self.bucket_name, Key=file_name, ContentType=content_type)
+
+    def upload_json_to_s3(self, json_obj, file_name, content_type):
+        self.s3.put_object(Body=json.dumps(json_obj), Bucket=self.bucket_name, Key=file_name, ContentType=content_type)
+
+    def upload_bytes_to_s3(self, bytes, file_name, content_type):
+        self.s3.put_object(Body=bytes, Bucket=self.bucket_name, Key=file_name, ContentType=content_type)

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,8 @@ setup(
         'python-dotenv',
         'requests',
         'sqlalchemy',
-        'frictionless'
+        'frictionless',
+        'boto3',
     ],
     package_data={},
     keywords='aircan, airflow, aircan-lib',


### PR DESCRIPTION
Generate CSV from dump URL and upload to GCP when the existing datastore table is appended, it needs to be implemented because downloading via dump URL consumes a significant process specifically when the request rate is too high.