### PR TITLE
feat(streamer): align CSV columns by header name for append/upsert (UNTESTED on Composer)

### DIFF
--- a/aircan/dags/pipeline_ckan_to_bigquery.py
+++ b/aircan/dags/pipeline_ckan_to_bigquery.py
@@ -377,6 +377,18 @@ def prepare_and_upload_task() -> Dict[str, Any]:
     if date_formats:
         logger.info("Reformatting date columns to ISO at positions: %s", list(date_formats))
 
+    # Emit CSV columns in the schema's field order, aligned to the source by
+    # header name (not source position). This lets append/upsert accept files
+    # whose columns are reordered, added, or omitted: values always land in the
+    # BigQuery column of the matching name, and a schema field absent from the
+    # source is written as NULL. date_formats above is keyed by this same field
+    # index, so it stays aligned.
+    field_order = [
+        str(field.get("name", "")).strip()
+        for field in descriptor.get("fields", [])
+        if str(field.get("name", "")).strip() not in system_columns
+    ]
+
     streamer_kwargs = {}
     if gcs_config.get("chunk_size"):
         streamer_kwargs["gcs_chunk_size"] = int(gcs_config["chunk_size"])
@@ -395,6 +407,7 @@ def prepare_and_upload_task() -> Dict[str, Any]:
         system_columns=system_columns,
         record_updated_at_column=record_updated_at_column,
         job_timestamp=job_timestamp,
+        field_order=field_order,
         **streamer_kwargs,
     ).stream()
 

--- a/aircan/dependencies/cloud/storage.py
+++ b/aircan/dependencies/cloud/storage.py
@@ -19,6 +19,8 @@ import pyarrow.parquet as pq
 
 import requests
 
+from ..utils.schema import sanitize_column_name
+
 logger = logging.getLogger(__name__)
 
 DEFAULT_CHUNK_SIZE = 8 * 1024 * 1024
@@ -78,6 +80,7 @@ class HttpToGCSStreamer:
         system_columns: Optional[list] = None,
         record_updated_at_column: Optional[str] = None,
         job_timestamp: Optional[datetime] = None,
+        field_order: Optional[list] = None,
     ):
         self.http_url = http_url
         self.storage_client = storage_client
@@ -106,6 +109,18 @@ class HttpToGCSStreamer:
         # Matched against raw source header / object keys, so they stay aligned
         # with the (also-stripped) schema descriptor.
         self.system_columns = [str(c).strip() for c in (system_columns or []) if c]
+        # Ordered schema field names (system columns excluded) used to align the
+        # CSV by *header name* instead of source position. When set, each output
+        # row is emitted in this exact order, pulling each field's value from the
+        # source by matching header name (a field missing from the source becomes
+        # empty -> NULL in BigQuery). This lets append/upsert accept files whose
+        # columns are reordered, added, or omitted without shifting data into the
+        # wrong column. date_formats stays valid because it is keyed by the
+        # descriptor field index, which equals this output order. When None, the
+        # legacy positional behaviour is used (output follows the source order).
+        self.field_order = (
+            [str(c).strip() for c in field_order] if field_order else None
+        )
 
     def _blob(self):
         return self.storage_client.bucket(self.bucket_name).blob(self.object_name)
@@ -186,18 +201,42 @@ class HttpToGCSStreamer:
                     buf = io.StringIO()
                     writer = csv.writer(buf, delimiter=sep)
 
-                    # Keep all columns except system ones (e.g. _id, _updated_at)
-                    # the source may already carry; date_formats reformats declared
-                    # date/time columns to ISO so BigQuery can parse them.
+                    # Decide the output columns and their source positions.
+                    # `out_names` is the emitted column order; `keep_idx[k]` is the
+                    # source-row index feeding output column k (None => the source
+                    # lacks that column, emitted as "" -> NULL).
                     header = next(reader, [])
-                    keep = [i for i, n in enumerate(header) if n.strip() not in self.system_columns]
-                    out_header = [self.row_number_column] + [header[i] for i in keep]
+                    if self.field_order is not None:
+                        # Name-based alignment: emit columns in schema order,
+                        # pulling each from the source by header name. Robust to
+                        # reordered / added / omitted source columns. Header names
+                        # are sanitized the same way the schema descriptor's field
+                        # names are (BigQuery-safe), so e.g. "Price (GBP)" in the
+                        # file matches the "Price_GBP" schema field.
+                        src_index = {
+                            sanitize_column_name(n): i for i, n in enumerate(header)
+                        }
+                        out_names = list(self.field_order)
+                        keep_idx = [src_index.get(n) for n in out_names]
+                    else:
+                        # Legacy positional behaviour: keep the source's own order,
+                        # dropping only system columns.
+                        keep = [
+                            i for i, n in enumerate(header)
+                            if n.strip() not in self.system_columns
+                        ]
+                        out_names = [header[i] for i in keep]
+                        keep_idx = keep
+                    out_header = [self.row_number_column] + out_names
                     if updated_col:
                         out_header.append(updated_col)
                     writer.writerow(out_header)
 
                     for row in reader:
-                        out = [row[i] if i < len(row) else "" for i in keep]
+                        out = [
+                            row[i] if (i is not None and i < len(row)) else ""
+                            for i in keep_idx
+                        ]
                         for idx, (fr_type, src_fmt) in self.date_formats.items():
                             if idx < len(out):
                                 out[idx] = _reformat_temporal(out[idx], fr_type, src_fmt)


### PR DESCRIPTION
> ⚠️ **NOT TESTED end-to-end.** The CSV-streaming logic was validated locally with stubbed
> deps (reordered / added / omitted / sanitized-header cases), but it has **not** run through a
> real dev-Composer → BigQuery load. Please validate on Composer before merging (steps below).
> Branched off **`master`** (the line synced to the dev Composer bucket). ⚠️ `master` has since
> advanced (e.g. the parquet-format commit); please confirm this rebases onto whatever is
> **actually deployed** in the Composer DAG bucket, since aircan is bucket-synced, not pinned.

## The issue
The CSV streamer preserves the **source file's** column order, and BigQuery then loads it
**positionally** against the schema (BQ maps CSV columns by ordinal, not header name). So an
append/upsert whose file has **reordered, added, or omitted** columns shifts data into the
wrong column — or fails the load. This blocks non-destructive column changes on append/upsert:
- a new column can't be added unless it's strictly last **and** the file keeps every existing
  column in its exact order;
- a reorder with type-compatible columns loads silently into the wrong columns (data corruption).

`ALLOW_FIELD_ADDITION` is already set on append loads, so BigQuery *can* add a new column — but
only if the streamed CSV is aligned to the schema by **name** first. That alignment is what's
missing.

## The proposed fix
Add a `field_order` option to the streamer. When set, each output row is emitted in **schema
field order**, pulling each column from the source **by sanitized header name**:
- column missing from the source → emitted empty → **NULL** in BigQuery;
- extra source columns → dropped;
- reordered source columns → placed correctly by name.

`date_formats` stays valid because it's keyed by the descriptor field index, which equals the
output order. When `field_order` is `None`, the legacy positional behaviour is unchanged. The
DAG passes the descriptor's field order.

Header names are sanitized the same way the schema descriptor's field names are (BigQuery-safe),
so e.g. `Price (GBP)` in the file matches the `Price_GBP` schema field.

Files: `aircan/dependencies/cloud/storage.py` (`_stream_csv`), `aircan/dags/pipeline_ckan_to_bigquery.py` (passes `field_order`).

## Why (frontend context)
The dx-helm-neso frontend now merges the uploaded file's schema with the stored one on
append/upsert (existing columns kept + locked, new columns appended). Today the FE **blocks**
reorder / mid-insert / missing because the deployed positional load can't handle them safely.
This change makes those layouts load correctly by name; once it's deployed, the FE flips its
capability flags and stops blocking them (no UI rewrite).

## How to validate (dev Composer → BigQuery)
Against an existing datastore table, run append/upsert with files that:
1. **Reorder** existing columns → rows land in the correct columns (not shifted).
2. **Add** a new column (schema includes it) → column added, existing rows NULL for it.
3. **Omit** a column → that column NULL-filled for the appended rows, others intact.
4. Have **sanitized-differing** headers (`Price (GBP)` vs `Price_GBP`) → matched by name.
Confirm row counts and per-column values in BigQuery after each.

## Not covered here
The create-with-upload **double-load** is a separate issue (ckanext-aircan `notify` dedupe +
frontend create-collapse) — not this PR.
