### PR TITLE
feat: order-independent append/upsert column merge across all formats

### DIFF
--- a/aircan/dags/pipeline_ckan_to_bigquery.py
+++ b/aircan/dags/pipeline_ckan_to_bigquery.py
@@ -42,6 +42,7 @@ from aircan.dependencies.cloud.warehouse import (
     bq_destination_format,
     export_file_ext,
     append_or_replace_flow,
+    append_flow,
     upsert_flow,
     export_bq_to_gcs,
     get_table_header,
@@ -377,6 +378,18 @@ def prepare_and_upload_task() -> Dict[str, Any]:
     if date_formats:
         logger.info("Reformatting date columns to ISO at positions: %s", list(date_formats))
 
+    # Emit the source columns in the schema's field order, aligned to the source
+    # by (sanitized) header/key name rather than source position. This lets
+    # append/upsert accept files whose columns are reordered, added anywhere, or
+    # omitted: values always land in the BigQuery column of the matching name,
+    # and a schema field absent from the source is written as NULL. date_formats
+    # above is keyed by this same field index, so it stays aligned.
+    field_order = [
+        str(field.get("name", "")).strip()
+        for field in descriptor.get("fields", [])
+        if str(field.get("name", "")).strip() not in system_columns
+    ]
+
     streamer_kwargs = {}
     if gcs_config.get("chunk_size"):
         streamer_kwargs["gcs_chunk_size"] = int(gcs_config["chunk_size"])
@@ -395,6 +408,7 @@ def prepare_and_upload_task() -> Dict[str, Any]:
         system_columns=system_columns,
         record_updated_at_column=record_updated_at_column,
         job_timestamp=job_timestamp,
+        field_order=field_order,
         **streamer_kwargs,
     ).stream()
 
@@ -441,32 +455,54 @@ def replace_or_append_table_task() -> None:
     project_id = gcs_config.get("project_id")
     dataset_id = gcs_config.get("dataset_id")
     resource_id = resource_dict.get("id")
-    skip_leading_rows = int(config.get("others_config", {}).get("skip_leading_rows", 1))
+    others_config = config.get("others_config", {})
+    skip_leading_rows = int(others_config.get("skip_leading_rows", 1))
+    temp_table_prefix = others_config.get("temp_table_prefix", "_temp_")
     source_format = prepare_result.get("source_format", "csv")
 
     client = bq_client(conn_id, project_id)
     ensure_dataset_exists(client, project_id, dataset_id)
+
+    schema_fields = build_schema_fields(
+        prepare_result["schema_descriptor"],
+        prepare_result.get("row_number_column"),
+        prepare_result.get("record_updated_at_column"),
+    )
+    target = table_fqn(project_id, dataset_id, resource_id)
 
     ckan_status_update_async(
         config,
         state="running",
         message=f"{'Appending' if write_method == 'append' else 'Replacing'} to BigQuery",
     )
-    append_or_replace_flow(
-        client,
-        prepare_result["gcs_uri"],
-        prepare_result["compression"],
-        table_fqn(project_id, dataset_id, resource_id),
-        write_method,
-        build_schema_fields(
-            prepare_result["schema_descriptor"],
-            prepare_result.get("row_number_column"),
-            prepare_result.get("record_updated_at_column"),
-        ),
-        skip_leading_rows,
-        source_format=source_format,
-        schema_descriptor=prepare_result["schema_descriptor"],
-    )
+    if write_method == "append":
+        # Append goes through a staging table and INSERTs into the target by
+        # column name, so the file's columns may be reordered and new columns
+        # may appear anywhere (see append_flow). Replace rebuilds the table, so
+        # it loads straight in — column order/new columns are inherently free.
+        append_flow(
+            client,
+            prepare_result["gcs_uri"],
+            prepare_result["compression"],
+            target,
+            table_fqn(project_id, dataset_id, f"{temp_table_prefix}{resource_id}"),
+            schema_fields,
+            skip_leading_rows,
+            source_format=source_format,
+            schema_descriptor=prepare_result["schema_descriptor"],
+        )
+    else:
+        append_or_replace_flow(
+            client,
+            prepare_result["gcs_uri"],
+            prepare_result["compression"],
+            target,
+            write_method,
+            schema_fields,
+            skip_leading_rows,
+            source_format=source_format,
+            schema_descriptor=prepare_result["schema_descriptor"],
+        )
     ckan_status_update_async(
         config, state="running", message=f"{write_method.capitalize()} complete"
     )

--- a/aircan/dependencies/cloud/storage.py
+++ b/aircan/dependencies/cloud/storage.py
@@ -165,7 +165,10 @@ class HttpToGCSStreamer:
         return f"gs://{self.bucket_name}/{self.object_name}"
 
     def _stream_csv(self) -> str:
-        sep = "\t" if self.fmt == "tsv" else ","
+        # Read with the source delimiter (tab for TSV), but always WRITE comma:
+        # the BigQuery load treats both csv and tsv as CSV with the default comma
+        # delimiter, so TSV must be normalised to comma-separated on the way out.
+        in_sep = "\t" if self.fmt == "tsv" else ","
         queue: Queue = Queue(maxsize=4)
         sentinel = object()
         exc_holder: list = [None]
@@ -181,10 +184,10 @@ class HttpToGCSStreamer:
                     resp.raise_for_status()
                     resp.raw.decode_content = True
                     text_in = codecs.getreader("utf-8")(resp.raw)
-                    reader = csv.reader(text_in, delimiter=sep)
+                    reader = csv.reader(text_in, delimiter=in_sep)
 
                     buf = io.StringIO()
-                    writer = csv.writer(buf, delimiter=sep)
+                    writer = csv.writer(buf, delimiter=",")
 
                     # Keep all columns except system ones (e.g. _id, _updated_at)
                     # the source may already carry; date_formats reformats declared

--- a/aircan/dependencies/cloud/storage.py
+++ b/aircan/dependencies/cloud/storage.py
@@ -19,6 +19,8 @@ import pyarrow.parquet as pq
 
 import requests
 
+from ..utils.schema import sanitize_column_name
+
 logger = logging.getLogger(__name__)
 
 DEFAULT_CHUNK_SIZE = 8 * 1024 * 1024
@@ -78,6 +80,7 @@ class HttpToGCSStreamer:
         system_columns: Optional[list] = None,
         record_updated_at_column: Optional[str] = None,
         job_timestamp: Optional[datetime] = None,
+        field_order: Optional[list] = None,
     ):
         self.http_url = http_url
         self.storage_client = storage_client
@@ -106,9 +109,38 @@ class HttpToGCSStreamer:
         # Matched against raw source header / object keys, so they stay aligned
         # with the (also-stripped) schema descriptor.
         self.system_columns = [str(c).strip() for c in (system_columns or []) if c]
+        # Ordered (sanitized) schema field names — system columns excluded — used
+        # to align the source to the schema by *name* instead of source position.
+        # When set, every format emits its data columns in exactly this order,
+        # pulling each value from the source by matching (sanitized) name: a field
+        # missing from the source becomes NULL, an extra source field is dropped.
+        # This lets append/upsert accept files whose columns are reordered, added
+        # (anywhere, not just at the end), or omitted, so data always lands in the
+        # BigQuery column of the matching name. date_formats is keyed by the
+        # descriptor field index, which equals this output order, so it stays
+        # aligned. When None, the legacy behaviour (follow the source order) runs.
+        self.field_order = (
+            [str(c).strip() for c in field_order] if field_order else None
+        )
 
     def _blob(self):
         return self.storage_client.bucket(self.bucket_name).blob(self.object_name)
+
+    def _align_obj(self, obj: dict) -> dict:
+        """Project a source JSON object onto the schema's field order.
+
+        With ``field_order`` set, returns a dict with exactly the schema fields,
+        in schema order, pulling each value from the source by sanitized key
+        (missing -> None -> NULL, extras dropped). Without it, falls back to the
+        legacy behaviour: keep the source keys, dropping only system columns.
+        """
+        if self.field_order is not None:
+            src = {sanitize_column_name(str(k)): v for k, v in obj.items()}
+            return {name: src.get(name) for name in self.field_order}
+        return {
+            k: v for k, v in obj.items()
+            if str(k).strip() not in self.system_columns
+        }
 
     def _stream_parquet(self) -> str:
         import fsspec
@@ -123,15 +155,36 @@ class HttpToGCSStreamer:
         ) as f:
             pf = pq.ParquetFile(f)
             original_schema = pf.schema_arrow
-            keep_fields = [
-                field.name
-                for field in original_schema
-                if field.name.strip() not in self.system_columns
-            ]
+            if self.field_order is not None:
+                # Name-based alignment: emit columns in schema order, renamed to
+                # their sanitized (BigQuery-safe) names so BigQuery maps them to
+                # the load schema by name. Extra source columns are dropped;
+                # schema fields absent from the source are simply omitted here and
+                # filled as NULL by BigQuery from the explicit load schema.
+                src_by_sani = {
+                    sanitize_column_name(field.name): field.name
+                    for field in original_schema
+                }
+                pairs = [
+                    (name, src_by_sani[name])
+                    for name in self.field_order
+                    if name in src_by_sani
+                ]
+                keep_src = [raw for _, raw in pairs]
+                data_fields = [
+                    pa.field(sani, original_schema.field(raw).type)
+                    for sani, raw in pairs
+                ]
+            else:
+                # Legacy: keep source order, drop only system columns.
+                keep_src = [
+                    field.name
+                    for field in original_schema
+                    if field.name.strip() not in self.system_columns
+                ]
+                data_fields = [original_schema.field(n) for n in keep_src]
             ts_type = pa.timestamp("us", tz="UTC")  # tz-aware -> BQ TIMESTAMP
-            new_fields = [pa.field(self.row_number_column, pa.int64())] + [
-                original_schema.field(n) for n in keep_fields
-            ]
+            new_fields = [pa.field(self.row_number_column, pa.int64())] + data_fields
             if self.record_updated_at_column:
                 new_fields.append(pa.field(self.record_updated_at_column, ts_type))
                 ts_scalar = pa.scalar(self.job_timestamp, type=ts_type)
@@ -140,12 +193,12 @@ class HttpToGCSStreamer:
             total_rows = 0
             with self._blob().open("wb", chunk_size=self.gcs_chunk_size) as gcs_out:
                 with pq.ParquetWriter(gcs_out, new_schema) as writer:
-                    for batch in pf.iter_batches(columns=keep_fields):
+                    for batch in pf.iter_batches(columns=keep_src):
                         num_rows = len(batch)
                         row_nums = pa.array(
                             range(counter, counter + num_rows), type=pa.int64()
                         )
-                        arrays = [row_nums] + [batch.column(n) for n in keep_fields]
+                        arrays = [row_nums] + [batch.column(n) for n in keep_src]
                         if self.record_updated_at_column:
                             arrays.append(pa.repeat(ts_scalar, num_rows))
                         new_batch = pa.RecordBatch.from_arrays(
@@ -189,18 +242,42 @@ class HttpToGCSStreamer:
                     buf = io.StringIO()
                     writer = csv.writer(buf, delimiter=",")
 
-                    # Keep all columns except system ones (e.g. _id, _updated_at)
-                    # the source may already carry; date_formats reformats declared
-                    # date/time columns to ISO so BigQuery can parse them.
+                    # Decide the output columns and the source position feeding
+                    # each. `out_names` is the emitted order; `keep_idx[k]` is the
+                    # source-row index for output column k (None => the source
+                    # lacks that column, emitted as "" -> NULL). date_formats
+                    # reformats declared date/time columns to ISO so BigQuery can
+                    # parse them.
                     header = next(reader, [])
-                    keep = [i for i, n in enumerate(header) if n.strip() not in self.system_columns]
-                    out_header = [self.row_number_column] + [header[i] for i in keep]
+                    if self.field_order is not None:
+                        # Name-based alignment: emit columns in schema order,
+                        # pulling each from the source by sanitized header name
+                        # (so "Price (GBP)" in the file matches the "Price_GBP"
+                        # schema field). Robust to reordered / added / omitted
+                        # source columns.
+                        src_index = {
+                            sanitize_column_name(n): i for i, n in enumerate(header)
+                        }
+                        out_names = list(self.field_order)
+                        keep_idx = [src_index.get(n) for n in out_names]
+                    else:
+                        # Legacy: keep the source's own order, drop system columns.
+                        keep = [
+                            i for i, n in enumerate(header)
+                            if n.strip() not in self.system_columns
+                        ]
+                        out_names = [header[i] for i in keep]
+                        keep_idx = keep
+                    out_header = [self.row_number_column] + out_names
                     if updated_col:
                         out_header.append(updated_col)
                     writer.writerow(out_header)
 
                     for row in reader:
-                        out = [row[i] if i < len(row) else "" for i in keep]
+                        out = [
+                            row[i] if (i is not None and i < len(row)) else ""
+                            for i in keep_idx
+                        ]
                         for idx, (fr_type, src_fmt) in self.date_formats.items():
                             if idx < len(out):
                                 out[idx] = _reformat_temporal(out[idx], fr_type, src_fmt)
@@ -259,8 +336,7 @@ class HttpToGCSStreamer:
                     if not raw_line:
                         continue
                     obj = _json.loads(raw_line)
-                    for key in self.system_columns:
-                        obj.pop(key, None)
+                    obj = self._align_obj(obj)
                     obj = {self.row_number_column: counter, **obj}
                     if updated_col:
                         obj[updated_col] = updated_iso
@@ -289,8 +365,7 @@ class HttpToGCSStreamer:
             response.raw.decode_content = True
             with self._blob().open("wb", chunk_size=self.gcs_chunk_size) as gcs_out:
                 for obj in ijson.items(response.raw, "item"):
-                    for key in self.system_columns:
-                        obj.pop(key, None)
+                    obj = self._align_obj(obj)
                     out = {self.row_number_column: counter, **obj}
                     if updated_col:
                         out[updated_col] = updated_iso

--- a/aircan/dependencies/cloud/warehouse.py
+++ b/aircan/dependencies/cloud/warehouse.py
@@ -667,6 +667,62 @@ def append_or_replace_flow(
     logger.info("Load complete into %s", target_fqn)
 
 
+def append_flow(
+    client: bigquery.Client,
+    gcs_uri: str,
+    compression: str,
+    target_fqn: str,
+    stage_fqn: str,
+    schema_fields: Optional[List[bigquery.SchemaField]],
+    skip_leading_rows: int,
+    source_format: str = "csv",
+    schema_descriptor: Optional[dict] = None,
+) -> None:
+    """Append rows to the target table, matching columns to it by NAME.
+
+    The file is loaded into a staging table first and then INSERTed into the
+    target by column name — never loaded positionally into the target. This
+    lets an append accept files whose columns are reordered and lets brand-new
+    columns appear anywhere in the file (not only at the end): any column the
+    target lacks is added before the INSERT, and a target column absent from the
+    file is left NULL for the new rows. Works uniformly for every source format.
+
+    The row-number and record-updated-at values are baked into the staged file
+    (see the streamer), so the INSERT carries them straight through — no
+    post-load schema patch or backfill UPDATE that would race concurrent runs.
+    """
+    logger.info("Loading into staging: %s", stage_fqn)
+    load_gcs_to_bq_table(
+        client=client,
+        source_uri=gcs_uri,
+        dest_fqn=stage_fqn,
+        compression=compression,
+        write_disposition=bigquery.WriteDisposition.WRITE_TRUNCATE,
+        schema_fields=schema_fields,
+        skip_leading_rows=skip_leading_rows,
+        source_format=source_format,
+    )
+    logger.info("Staging load complete")
+
+    ensure_target_exists_from_stage(client, target_fqn, stage_fqn)
+    stage_table = client.get_table(stage_fqn)
+    # Add any columns the staged file introduced (new columns can appear anywhere
+    # in the file — they are matched by name, not position).
+    ensure_table_has_fields(client, target_fqn, stage_table.schema)
+
+    col_list = ", ".join(f"`{field.name}`" for field in stage_table.schema)
+    logger.info("Appending into %s (columns: %s)", target_fqn, col_list)
+    client.query(
+        f"INSERT INTO `{target_fqn}` ({col_list}) "
+        f"SELECT {col_list} FROM `{stage_fqn}`"
+    ).result()
+
+    apply_table_options(client, target_fqn, schema_descriptor)
+
+    client.delete_table(stage_fqn, not_found_ok=True)
+    logger.info("Append complete into %s", target_fqn)
+
+
 def get_table_header(client: bigquery.Client, source_fqn: str) -> str:
     """Return the CSV header row for a BigQuery table (comma-separated column names + newline)."""
     table = client.get_table(source_fqn)

--- a/aircan/dependencies/utils/validation.py
+++ b/aircan/dependencies/utils/validation.py
@@ -5,6 +5,8 @@ import requests
 
 from frictionless import Resource, Schema, system
 
+from .schema import sanitize_column_name
+
 logger = logging.getLogger(__name__)
 
 
@@ -44,11 +46,22 @@ class ResourceValidator:
 
             descriptor_fields = schema_descriptor.get("fields", [])
             if header:
+                # Match each source column to the schema field of the same
+                # (sanitized) name, then build the validation schema in the
+                # file's column order. This checks types by name, not position,
+                # so a file whose columns are reordered validates correctly. A
+                # source column with no matching schema field (a new column) is
+                # validated without a type constraint.
+                by_name = {
+                    sanitize_column_name(str(f.get("name", ""))): f
+                    for f in descriptor_fields
+                    if isinstance(f, dict)
+                }
                 schema_descriptor["fields"] = [
-                    {**dict(descriptor_fields[i]), "name": str(col_name)}
-                    for i, col_name in enumerate(header)
-                    if i < len(descriptor_fields)
-                    and isinstance(descriptor_fields[i], dict)
+                    {**dict(by_name[key]), "name": str(col_name)}
+                    if (key := sanitize_column_name(str(col_name))) in by_name
+                    else {"name": str(col_name)}
+                    for col_name in header
                 ]
 
             schema_obj = Schema.from_descriptor(schema_descriptor)


### PR DESCRIPTION
Part of datopian/neso-nextgen-shared#139 (point III + the pipeline side).

## What
Make append/upsert accept data files whose columns are **reordered**, whose **new columns appear anywhere** (not only at the end), or which **omit** a column — for **every supported format** (csv, tsv, json, ndjson/jsonl, parquet). Columns are matched to the target table by **name**, not by ordinal position.

## Changes
- **`fix(streamer): normalize TSV output to comma`** — the streamer wrote TSV with tabs, but BigQuery loads tsv as CSV with the default comma delimiter, so every TSV row failed. Read with the source delimiter, always write comma.
- **`feat: align columns by name across all formats`**
  - Streamer gains `field_order`: each format emits its data columns in schema order, pulled from the source by sanitized name (missing → NULL, extras dropped).
  - `warehouse.append_flow`: load into a staging table, add any new columns to the target, then `INSERT … SELECT` **by column name** (append now matches the target by name like upsert's MERGE, instead of positionally). Replace still loads straight in (it rebuilds the table).
  - DAG computes `field_order` and routes append → `append_flow`.
- **`fix(validation): match records validation to schema by column name`** — `validate_records` rebuilt the schema positionally, so a reordered file failed type validation; now each source column is validated against the schema field of the same name.

## Verification
Ran against real BigQuery via a local Airflow (Composer-equivalent, Airflow 3.1.7) for all six formats: replace → then append/upsert with reordered columns + a new **middle** column + a missing column. Every case mapped data into the correct BQ column by name (`_id`/`_updated_at` preserved, upsert MERGE on the primary key). Also confirmed end-to-end through the CKAN UI.

## Notes
- Branched off `master` (matches what's deployed to the `dx-airflow-v3-production` Composer DAG bucket).
- Pairs with ckanext-aircan + dx-helm-neso PRs (same branch name).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved append ingestion with safer column-name matching when adding data to existing tables.
  * Added support for handling reordered, missing, or newly added source columns.
  * CSV, JSON, and Parquet uploads now align data with the configured schema and fill missing values appropriately.

* **Bug Fixes**
  * Corrected CSV schema validation to match columns by sanitized names instead of position.
  * Standardized streamed CSV output to comma-delimited format, including TSV inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->